### PR TITLE
Fix typos

### DIFF
--- a/_posts/2013-08-15-lesson-0-linux-command-line.md
+++ b/_posts/2013-08-15-lesson-0-linux-command-line.md
@@ -15,7 +15,7 @@ If you've installed it through your package manager or placed the libraries
 and headers elsewhere you may need to change these paths to match your installation. You can also check the output
 of `sdl2-config` with the `--cflags` and `--libs` switches to locate your install, assuming you haven't moved it.
 
-If you're unfamiliar with Makefiles a basic introduction can be found [here](http://mrbook.org/tutorials/make/)
+If you're unfamiliar with Makefiles a basic introduction can be found [here](http://mrbook.org/tutorials/make/).
 
 <!--more-->
 

--- a/_posts/2013-08-15-lesson-0-visual-studio.md
+++ b/_posts/2013-08-15-lesson-0-visual-studio.md
@@ -65,7 +65,7 @@ path your entry should look like this if SDL is under `C:\` and you chose the 32
 Adding the Library Dependencies
 -
 Now we'll add the libraries themselves as dependencies. Switch to the **Input** page and open
-the **Additonal Dependencies** entry's edit panel and add `SDL2.lib; SDL2main.lib`.
+the **Additional Dependencies** entry's edit panel and add `SDL2.lib; SDL2main.lib`.
 Once you've done this your Input page should look like so:
 
 <br />

--- a/_posts/2013-08-17-lesson-2-dont-put-everything-in-main.md
+++ b/_posts/2013-08-17-lesson-2-dont-put-everything-in-main.md
@@ -26,13 +26,13 @@ The SDL Error Logger
 -
 Throughout lesson 1 we had a lot of repeated code used to print out error messages that was almost the same
 for each error, except for some different information about which function went wrong. We can improve on this
-with a more generic error logging function that can take any `std::ostream` to write too, a message to print
+with a more generic error logging function that can take any `std::ostream` to write to, a message to print
 and will write out the message along with the error message from `SDL_GetError` to the stream.
 
 {% highlight c++ %}
 /**
 * Log an SDL error with some error message to the output stream of our choice
-* @param os The output stream to write the message too
+* @param os The output stream to write the message to
 * @param msg The error message to write, format will be msg error: SDL_GetError()
 */
 void logSDLError(std::ostream &os, const std::string &msg){
@@ -51,7 +51,7 @@ to do this for us.
 
 First we initialize an `SDL_Texture*` to `nullptr` so that in case of an error a valid 
 `nullptr` is returned instead of a dangling pointer. Next we'll load up the BMP as before and check for errors,
-using our new `logSDLError` function to print out any errors that occured. If the surface loads ok we then
+using our new `logSDLError` function to print out any errors that occurred. If the surface loads ok we then
 create the texture from the surface and perform an error check on that. If everything goes ok we get back
 a valid pointer, if not we'll get back a `nullptr` and the error messages will show up in our log.
 
@@ -90,7 +90,7 @@ width and height. To do this we'll need to create a destination rectangle to pas
 [`SDL_RenderCopy`](http://wiki.libsdl.org/moin.fcg/SDL_RenderCopy) and get the texture's width and height with 
 [`SDL_QueryTexture`](http://wiki.libsdl.org/moin.fcg/SDL_QueryTexture) so that its size will be 
 preserved when rendering. This is a lot to do each time we want to draw, so we'll create a 
-function, `renderTexture`, that will take the x and y coordinates to draw too, the texture
+function, `renderTexture`, that will take the x and y coordinates to draw to, the texture
 and the renderer and will setup the destination rectangle correctly and draw the texture.
 
 The destination rectangle is a [`SDL_Rect`](http://wiki.libsdl.org/moin.fcg/SDL_Rect) with the x and y
@@ -106,9 +106,9 @@ values to shrink or stretch the texture as desired.
 * Draw an SDL_Texture to an SDL_Renderer at position x, y, preserving
 * the texture's width and height
 * @param tex The source texture we want to draw
-* @param ren The renderer we want to draw too
-* @param x The x coordinate to draw too
-* @param y The y coordinate to draw too
+* @param ren The renderer we want to draw to
+* @param x The x coordinate to draw to
+* @param y The y coordinate to draw to
 */
 void renderTexture(SDL_Texture *tex, SDL_Renderer *ren, int x, int y){
 	//Setup the destination rectangle to be at the position we want
@@ -125,7 +125,7 @@ void renderTexture(SDL_Texture *tex, SDL_Renderer *ren, int x, int y){
 Creating the Window and Renderer
 -
 We initialize SDL and create our window and renderer the same as in lesson 1 but now we use our `logSDLError`
-function to print out any errors that occured and use the constants we defined earlier as the screen width
+function to print out any errors that occurred and use the constants we defined earlier as the screen width
 and height.
 {% highlight c++ %}
 if (SDL_Init(SDL_INIT_EVERYTHING) != 0){
@@ -192,7 +192,7 @@ the texture width, height or both depending on the location we want it at so tha
 We can retrieve the texture's width through `SDL_QueryTexture` like we did in `renderTexture` 
 and then draw each tile, adjusting each draw over and down as needed.
 
-**Excercise Problem:** While it's not so bad to type out the draw positions for just four tiles
+**Exercise Problem:** While it's not so bad to type out the draw positions for just four tiles
 it would be ridiculous to do so if we wanted to put down a large number of tiles. How could we compute
 the tile positions to fill the screen completely?
 
@@ -251,7 +251,7 @@ If everything went well and you used the images provided you should see this dra
 <img class="centered" width="500" height="auto" src="/assets/img/lesson_2/result.png">
 <br />
 
-If you have any issues check your error log to see where problems may have occured and/or post a comment below.
+If you have any issues check your error log to see where problems may have occurred and/or post a comment below.
 
 I'll see you again soon in [Lesson 3: SDL Extension Libraries!]({% post_url 2013-08-18-lesson-3-sdl-extension-libraries %})
 

--- a/_posts/2013-08-18-lesson-3-sdl-extension-libraries.md
+++ b/_posts/2013-08-18-lesson-3-sdl-extension-libraries.md
@@ -57,7 +57,7 @@ const int TILE_SIZE = 40;
 
 Loading Textures with SDL_image
 -
-SDL_image lets us load mulitple types of images along with allowing us to load them directly to an SDL_Texture
+SDL_image lets us load multiple types of images along with allowing us to load them directly to an SDL_Texture
 with `IMG_LoadTexture`. With this function almost all of our `loadTexture` code can be replaced and now
 we call `IMG_LoadTexture` to load the texture, check for errors and return. 
 We can still use `logSDLError` to log errors from the SDL_image library as the [`IMG_GetError`](http://www.libsdl.org/projects/SDL_image/docs/SDL_image.html#SEC45) function is just a [define](http://hg.libsdl.org/SDL_image/file/fa3faec630de/SDL_image.h#l137) of `SDL_GetError`.
@@ -94,9 +94,9 @@ To set the texture's width and height for drawing we simply write the width and 
 * Draw an SDL_Texture to an SDL_Renderer at position x, y, with some desired
 * width and height
 * @param tex The source texture we want to draw
-* @param rend The renderer we want to draw too
-* @param x The x coordinate to draw too
-* @param y The y coordinate to draw too
+* @param ren The renderer we want to draw to
+* @param x The x coordinate to draw to
+* @param y The y coordinate to draw to
 * @param w The width of the texture to draw
 * @param h The height of the texture to draw
 */
@@ -119,9 +119,9 @@ function will just get the width and height from the texture then call our new `
 * Draw an SDL_Texture to an SDL_Renderer at position x, y, preserving
 * the texture's width and height
 * @param tex The source texture we want to draw
-* @param rend The renderer we want to draw too
-* @param x The x coordinate to draw too
-* @param y The y coordinate to draw too
+* @param ren The renderer we want to draw to
+* @param x The x coordinate to draw to
+* @param y The y coordinate to draw to
 */
 void renderTexture(SDL_Texture *tex, SDL_Renderer *ren, int x, int y){
 	int w, h;
@@ -133,7 +133,7 @@ void renderTexture(SDL_Texture *tex, SDL_Renderer *ren, int x, int y){
 
 Initialize SDL_image (Optional)
 -
-When loading an image for the first time SDL_image will automatically initliaze the necessary image loading
+When loading an image for the first time SDL_image will automatically initialize the necessary image loading
 subsystem, however this will cause some delay in loading the image since SDL_image will have to perform
 its initialization setup first. If you'd like to initialize SDL_image earlier
 to avoid the delay when loading an image type for the first time you can do so with 
@@ -184,7 +184,7 @@ if (background == nullptr || image == nullptr)
 Tiling the Background
 -
 Since our tiles are much smaller now we'll need a lot more than 4 to cover the entire screen and typing their
-positions out by hand would be a real pain. Instead lets generate the tile draw positions to fill the screen
+positions out by hand would be a real pain. Instead let's generate the tile draw positions to fill the screen
 by using some math!
 
 We can determine how many tiles each row will need by dividing the `SCREEN_WIDTH` by the `TILE_SIZE`. To determine

--- a/_posts/2013-08-20-lesson-4-handling-events.md
+++ b/_posts/2013-08-20-lesson-4-handling-events.md
@@ -24,7 +24,7 @@ The first change we need to make is to load our new image to display a prompt fo
 
 A Basic Main Loop
 -
-We'll be adding a main loop to keep the program running until the user quits so that they can use it as long as they want too, instead of for some fixed delay period. The structure of this loop will be very basic.
+We'll be adding a main loop to keep the program running until the user quits so that they can use it as long as they want to, instead of for some fixed delay period. The structure of this loop will be very basic.
 
 {% highlight c++ %}
 while (!quit){
@@ -37,7 +37,7 @@ while (!quit){
 The SDL Event Queue
 -
 To properly use SDL's event system we'll need at least some understanding of how SDL handles events. When SDL
-recieves an event it's pushed onto the back of a queue of all the other events that have been recieved but haven't been
+receives an event it's pushed onto the back of a queue of all the other events that have been received but haven't been
 polled yet. If we were to start our program and then resize the window, click the 
 mouse and press a key the event queue would look like this.
 
@@ -51,7 +51,7 @@ it out later!
 
 Processing the Events
 -
-In our main loop we'll want to read in every event that's occured since the previous frame and handle them, 
+In our main loop we'll want to read in every event that's occurred since the previous frame and handle them, 
 we can do this by putting [`SDL_PollEvent`](http://wiki.libsdl.org/SDL_PollEvent) in a while loop, since the function will return 1 if an event was read in
 and 0 if not. Since all we'll do is quit the program when we get an event we'll set a quit bool to track
 whether the main loop should exit or not. So our event processing loop could look like this.
@@ -74,7 +74,7 @@ while (SDL_PollEvent(&e)){
 
 The `SDL_QUIT` event occurs when the user closes our window, `SDL_KEYDOWN` occurs when a key is pressed and
 `SDL_MOUSEBUTTONDOWN` occurs if a mouse button is pressed. These are just a few of the wide variety of events
-that we can recieve and I strongly recommend reading up about the other types in the
+that we can receive and I strongly recommend reading up about the other types in the
 [`SDL_Event` documentation](http://wiki.libsdl.org/SDL_Event).
 
 Completing the Main Loop

--- a/_posts/2013-08-27-lesson-5-clipping-sprite-sheets.md
+++ b/_posts/2013-08-27-lesson-5-clipping-sprite-sheets.md
@@ -41,7 +41,7 @@ keep some of the shorter syntax and conveniences from before.
 
 Modifying renderTexture
 -
-To keep from tacking on more and more parameters to our renderTexture function and still mantain the convenience
+To keep from tacking on more and more parameters to our renderTexture function and still maintain the convenience
 the defaults provided we'll split it up into two functions. One is practically an identical call
 to `SDL_RenderCopy` but provides the clip parameter with a default `nullptr` value. This version of renderTexture will take 
 the destination as rect instead, which we can setup ourselves or have constructed by one of our other specialized 
@@ -52,8 +52,8 @@ renderTexture functions. The new base rendering function becomes very simple.
 * Draw an SDL_Texture to an SDL_Renderer at some destination rect
 * taking a clip of the texture if desired
 * @param tex The source texture we want to draw
-* @param rend The renderer we want to draw too
-* @param dst The destination rectangle to render the texture too
+* @param ren The renderer we want to draw to
+* @param dst The destination rectangle to render the texture to
 * @param clip The sub-section of the texture to draw (clipping rect)
 *		default of nullptr draws the entire texture
 */
@@ -80,9 +80,9 @@ our original renderTexture function, and should look pretty similar.
 * If a clip is passed, the clip's width and height will be used instead of
 *	the texture's
 * @param tex The source texture we want to draw
-* @param rend The renderer we want to draw too
-* @param x The x coordinate to draw too
-* @param y The y coordinate to draw too
+* @param ren The renderer we want to draw to
+* @param x The x coordinate to draw to
+* @param y The y coordinate to draw to
 * @param clip The sub-section of the texture to draw (clipping rect)
 *		default of nullptr draws the entire texture
 */
@@ -150,7 +150,7 @@ in by checking the keycode information in the event, `e.key.keysym.sym`.
 A full list of [event types](http://wiki.libsdl.org/SDL_EventType), [key codes](http://wiki.libsdl.org/SDL_Keycode)
 and other [`SDL_Event`](http://wiki.libsdl.org/SDL_Event) information is available in the wiki.
 
-When we recieve the key input we're interested in we'll need to update the value of useClip to match the clip
+When we receive the key input we're interested in we'll need to update the value of useClip to match the clip
 we want to draw. With these additions our event loop will become:
 
 {% highlight c++ %}

--- a/_posts/2013-12-18-lesson-6-true-type-fonts-with-sdl_ttf.md
+++ b/_posts/2013-12-18-lesson-6-true-type-fonts-with-sdl_ttf.md
@@ -40,7 +40,7 @@ To make this easy for ourselves we'll create a function `renderText` that will t
 the TTF font we want to use, the color and size we want and the renderer to load the final texture into. The
 function will then open the font, render the text, convert it to a texture and return the texture. Since there
 could be some problems along the way we'll also need to check each of our library calls for errors and handle
-them appropriately, ie. clean up any resources, log the error and return `nullptr` so we know something bad happened.
+them appropriately, i.e. clean up any resources, log the error and return `nullptr` so we know something bad happened.
 SDL_ttf will report any of its errors through `SDL_GetError` so we can continue to use `logSDLError`
 for error logging.
 
@@ -96,7 +96,7 @@ Initializing SDL_ttf
 -
 As with SDL we need to initialize the library before we can use it. This is done via
 [`TTF_Init`](http://www.libsdl.org/projects/SDL_ttf/docs/SDL_ttf_8.html#SEC8) which will return 0 on success. To
-initialize SDL_ttf we just call this function after intializing SDL and check the return value to make sure it went ok.
+initialize SDL_ttf we just call this function after initializing SDL and check the return value to make sure it went ok.
 
 {% highlight c++ %}
 if (TTF_Init() != 0){

--- a/pages/sdl2/index.html
+++ b/pages/sdl2/index.html
@@ -8,7 +8,7 @@ description: ""
 <h2>Welcome!</h2>
 <p>
 The goal of the following tutorials is to provide you with an introduction to SDL2 in C++. It's assumed
-throught the series that you have some familiarity with C++ and are comfortable with functions, classes
+throughout the series that you have some familiarity with C++ and are comfortable with functions, classes
 and memory management. If you find yourself having trouble understanding the code in the tutorials
 feel free to comment on the lesson and/or grab a good C++ book from this excellent list on
 <a href="http://stackoverflow.com/questions/388242/the-definitive-c-book-guide-and-list">StackOverflow</a>.


### PR DESCRIPTION
This primarily corrects typos, including a couple of cases in which parameter names are spelled differently in the comment and in the argument list in the sample code.  I added a period in the Linux command line setup instructions (in the "If you're unfamiliar with Makefiles" sentence), because the MinGW and Mac command line setup instructions contain the same sentence and both include a period.
